### PR TITLE
feat: upload local disk images

### DIFF
--- a/hcloudimages/internal/sshsession/session.go
+++ b/hcloudimages/internal/sshsession/session.go
@@ -1,12 +1,21 @@
 package sshsession
 
-import "golang.org/x/crypto/ssh"
+import (
+	"io"
 
-func Run(client *ssh.Client, cmd string) ([]byte, error) {
+	"golang.org/x/crypto/ssh"
+)
+
+func Run(client *ssh.Client, cmd string, stdin io.Reader) ([]byte, error) {
 	sess, err := client.NewSession()
+
 	if err != nil {
 		return nil, err
 	}
 	defer sess.Close()
+
+	if stdin != nil {
+		sess.Stdin = stdin
+	}
 	return sess.CombinedOutput(cmd)
 }


### PR DESCRIPTION
The new options/flag enables users to use a local file as the image, instead of a publicly available file from a web server.