### PR TITLE
fix(cli): completion requires HCLOUD_TOKEN

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -23,7 +23,11 @@ $ hcloud ssh-key list -l apricote.de/created-by=hcloud-upload-image
 
 This command does not handle any parallel executions of hcloud-upload-image
 and will remove in-use resources if called at the same time.`,
+
 	GroupID: "primary",
+
+	PreRun: initClient,
+
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := contextlogger.From(ctx)

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -33,6 +33,8 @@ This does cost a bit of money for the server.`,
 
 	GroupID: "primary",
 
+	PreRun: initClient,
+
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := contextlogger.From(ctx)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/apricote/hcloud-upload-image
 go 1.22.2
 
 require (
-	github.com/apricote/hcloud-upload-image/hcloudimages v0.0.0
+	github.com/apricote/hcloud-upload-image/hcloudimages v0.2.0
 	github.com/hetznercloud/hcloud-go/v2 v2.8.0
 	github.com/spf13/cobra v1.8.0
 )


### PR DESCRIPTION
The current setup of the CLI requires the user to set HCLOUD_TOKEN for every single invocation of the binary. Even if we just want to autocomplete some arguments or even generate the completion scripts in CI.

This fixes the bug by only initializing the hcloud-go client in the "cleanup" and "upload" subcommands.