### PR TITLE
feat(cli): nix flake for CLI

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,7 +8,7 @@
     ".": {
       "component": "cli",
       "package-name": "hcloud-upload-image",
-      "extra-files": ["internal/version/version.go"]
+      "extra-files": ["internal/version/version.go", "hcloud-upload-image.nix"]
     },
     "hcloudimages": {
       "component": "hcloudimages",

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1715961556,
+        "narHash": "sha256-+NpbZRCRisUHKQJZF3CT+xn14ZZQO+KjxIIanH3Pvn4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4a6b83b05df1a8bd7d99095ec4b4d271f2956b64",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable"; # unstable for go 1.22
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          system = system;
+        };
+        hcloud-upload-image = pkgs.callPackage ./hcloud-upload-image.nix { };
+      in
+      {
+        packages = {
+          default = hcloud-upload-image;
+        };
+
+        devShells = {
+          default = pkgs.mkShell {
+            packages = [ hcloud-upload-image ];
+          };
+        };
+      }
+    );
+}

--- a/hcloud-upload-image.nix
+++ b/hcloud-upload-image.nix
@@ -1,0 +1,44 @@
+{ config, pkgs, fetchFromGitHub, ... }:
+
+pkgs.buildGo122Module rec {
+  pname = "hcloud-upload-image";
+  version = "v0.2.1"; # x-release-please-version
+  #src = pkgs.fetchFromGitHub {
+  #  owner = "apricote";
+  #  repo = "hcloud-upload-image";
+  #  rev = version;
+  #  sha256 = "KYhmMo/GDiLOWuEtdiY/KDwh1MO3crAFN2SGiL8FFIU=";
+  #};
+  src = ./.;
+
+  vendorHash = "";
+  overrideModAttrs = _: {
+    #outputHash = "sha256-/FluEFTvrX07L4kGPH7jPrcRhwdrCz1p4OVErNegNLw=";
+    #outputHash = null;
+    #outputHashAlgo = null;
+    #outputHashMode = null;
+  };
+
+  nativeBuildInputs = [
+    pkgs.installShellFiles
+  ];
+
+  preBuild = ''
+    export GOWORK=off
+  '';
+
+  subPackages = [ "." ]; # We only need to CLI, fails with the "hcloudimages" module otherwise
+  CGO_ENABLED = "0";
+
+  ldflags = [
+    "-X github.com/apricote/hcloud-upload-image/internal/version.version=${version}"
+    "-X github.com/apricote/hcloud-upload-image/internal/version.versionPrerelease="
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd hcloud-upload-image \
+      --bash <($out/bin/hcloud-upload-image completion bash) \
+      --fish <($out/bin/hcloud-upload-image completion fish) \
+      --zsh <($out/bin/hcloud-upload-image completion zsh)
+  '';
+}


### PR DESCRIPTION
This is missing some nice way to automatically update the nix version when a new tag is created. This was hard to automate as we need the full hash of the tag, but we only have that after we have updated this file (loopy loop).