### PR TITLE
feat: update default x86 server type to cx22

### DIFF
--- a/hcloudimages/client.go
+++ b/hcloudimages/client.go
@@ -34,11 +34,11 @@ var (
 	}
 
 	serverTypePerArchitecture = map[hcloud.Architecture]*hcloud.ServerType{
-		hcloud.ArchitectureX86: {Name: "cx11"},
+		hcloud.ArchitectureX86: {Name: "cx22"},
 		hcloud.ArchitectureARM: {Name: "cax11"},
 	}
 
-	defaultImage      = &hcloud.Image{Name: "ubuntu-22.04"}
+	defaultImage      = &hcloud.Image{Name: "ubuntu-24.04"}
 	defaultLocation   = &hcloud.Location{Name: "fsn1"}
 	defaultRescueType = hcloud.ServerRescueTypeLinux64
 


### PR DESCRIPTION
`cx11` is deprecated and will be removed in September.

Changelog: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated