### PR TITLE
Add Dockerfile and instructions to use it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.23-alpine AS builder
+
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /usr/src/app
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o /usr/src/app/dist/ ./...
+
+FROM scratch AS runtime
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /usr/src/app/dist/hcloud-upload-image /bin/hcloud-upload-image
+
+ENTRYPOINT ["/bin/hcloud-upload-image"]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ Use your preferred wrapper to install:
 yay -S hcloud-upload-image-bin
 ```
 
+#### Docker
+
+You can build a Docker image by cli command(from the root of this repo):
+
+```shell
+docker build -t hcloud-upload-image .
+```
+
+And the next, you can use it like this(for example):
+
+```shell
+docker run -ti --rm -e HCLOUD_TOKEN="<your token>" \
+  --image-url "https://example.com/disk-image-x86.raw.bz2" \
+  --architecture x86 \
+  --compression bz2
+```
+
 #### `go install`
 
 If you already have a recent Go toolchain installed, you can build & install the binary from source:


### PR DESCRIPTION
Added Dockerfile to create the possibility of using this tool with Docker, and instructions to use with Docker.
Also, it creates the possibility of building and publishing Docker images by GitLab Actions.