### PR TITLE
chore: lower ssh retry exponential backoff limit

### DIFF
--- a/hcloudimages/internal/control/retry.go
+++ b/hcloudimages/internal/control/retry.go
@@ -18,7 +18,7 @@ func Retry(ctx context.Context, maxTries int, f func() error) error {
 
 	var err error
 
-	backoffFunc := backoff.ExponentialBackoffWithLimit(2, 1*time.Second, 30*time.Second)
+	backoffFunc := backoff.ExponentialBackoffWithLimit(2, 200*time.Millisecond, 2*time.Second)
 
 	for try := 0; try < maxTries; try++ {
 		if ctx.Err() != nil {


### PR DESCRIPTION
The process is already slow enough, no need to waste so much time between SSH attempts.