### PR TITLE
chore(release): open separate prs for lib and cli

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,7 +3,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "release-type": "go",
-  "group-pull-request-title-pattern": "chore(${branch}): release ${version}",
+  "separate-pull-requests": true,
   "packages": {
     ".": {
       "component": "cli",


### PR DESCRIPTION
The CLI depends on the lib, and to make sure that users who install through `go install` use the correct version, we need to cut a release for the lib first, bump in CLI and then release CLI.