### PR TITLE
chore(release): disable version link between lib and cli

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -16,14 +16,5 @@
       "include-component-in-tag": true,
       "tag-separator": "/"
     }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "repo",
-      "components": [
-        "cli", "hcloudimages"
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Needed to be able to release lib first.