### PR TITLE
cmd/upload: document "raw" default for --format argument

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -127,7 +127,7 @@ func init() {
 		cobra.FixedCompletions([]string{string(hcloudimages.CompressionBZ2), string(hcloudimages.CompressionXZ)}, cobra.ShellCompDirectiveNoFileComp),
 	)
 
-	uploadCmd.Flags().String(uploadFlagFormat, "", "Format of the image. [choices: qcow2]")
+	uploadCmd.Flags().String(uploadFlagFormat, "", "Format of the image. [default: raw, choices: qcow2]")
 	_ = uploadCmd.RegisterFlagCompletionFunc(
 		uploadFlagFormat,
 		cobra.FixedCompletions([]string{string(hcloudimages.FormatQCOW2)}, cobra.ShellCompDirectiveNoFileComp),

--- a/docs/reference/cli/hcloud-upload-image_upload.md
+++ b/docs/reference/cli/hcloud-upload-image_upload.md
@@ -36,7 +36,7 @@ hcloud-upload-image upload (--image-path=<local-path> | --image-url=<url>) --arc
       --architecture string     CPU architecture of the disk image [choices: x86, arm]
       --compression string      Type of compression that was used on the disk image [choices: bz2, xz]
       --description string      Description for the resulting image
-      --format string           Format of the image. [choices: qcow2]
+      --format string           Format of the image. [default: raw, choices: qcow2]
   -h, --help                    help for upload
       --image-path string       Local path to the disk image that should be uploaded
       --image-url string        Remote URL of the disk image that should be uploaded


### PR DESCRIPTION
When first using the tool, based on the `--help` output I did not realize that `raw` was a supported format. Then, upon stumbling on a GitHub issue that documents this format as being able to stream larger images directly to disk, I found out that specifying `--format raw` does not work, and leads to a failure relatively late in the image upload process.

This documents that, when not specifying `--format`, a default format of `raw` is assumed.

## Discussion

I find the current semantics of the `--format` flag confusing. Having an implicit default format is fine, but it's confusing when that format is not one of the supported format options.

I am happy to do a slightly more invasive follow-up PR that changes the `FormatRaw` const to be `raw` and adds an explicit default for `""` to map to `FormatRaw` when parsing arguments, if this is desirable.

And lastly, thanks for creating this tool. It is awesome!
