### PR TITLE
feat: update default x86 server type to cx23

### DIFF
--- a/hcloudimages/client.go
+++ b/hcloudimages/client.go
@@ -34,7 +34,7 @@ var (
 	}
 
 	serverTypePerArchitecture = map[hcloud.Architecture]*hcloud.ServerType{
-		hcloud.ArchitectureX86: {Name: "cx22"},
+		hcloud.ArchitectureX86: {Name: "cx23"},
 		hcloud.ArchitectureARM: {Name: "cax11"},
 	}
 


### PR DESCRIPTION
`cx22` is deprecated and will be removed in January 2026.

Changelog: https://docs.hetzner.cloud/changelog#2025-10-16-server-types-deprecated