### PR TITLE
feat: add --location flag to specify datacenter region

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ export HCLOUD_TOKEN="<your token>"
 hcloud-upload-image upload \
   --image-url "https://example.com/disk-image-x86.raw.bz2" \
   --architecture x86 \
-  --compression bz2
+  --compression bz2 \
+  --location nbg1  # Optional: defaults to fsn1
 ```
 
 To learn more, you can use the embedded help output or check out the [CLI help pages in this repository](docs/reference/cli/hcloud-upload-image.md).:
@@ -123,6 +124,7 @@ func main() {
 		ImageURL:         imageURL,
 		ImageCompression: hcloudimages.CompressionBZ2,
 		Architecture:     hcloud.ArchitectureX86,
+		Location:         &hcloud.Location{Name: "nbg1"}, // Optional: defaults to fsn1
 	})
 	if err != nil {
 		panic(err)

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -23,6 +23,7 @@ const (
 	uploadFlagServerType   = "server-type"
 	uploadFlagDescription  = "description"
 	uploadFlagLabels       = "labels"
+	uploadFlagLocation     = "location"
 )
 
 //go:embed upload.md
@@ -54,6 +55,7 @@ var uploadCmd = &cobra.Command{
 		serverType, _ := cmd.Flags().GetString(uploadFlagServerType)
 		description, _ := cmd.Flags().GetString(uploadFlagDescription)
 		labels, _ := cmd.Flags().GetStringToString(uploadFlagLabels)
+		location, _ := cmd.Flags().GetString(uploadFlagLocation)
 
 		options := hcloudimages.UploadOptions{
 			ImageCompression: hcloudimages.Compression(imageCompression),
@@ -102,6 +104,10 @@ var uploadCmd = &cobra.Command{
 			options.ServerType = &hcloud.ServerType{Name: serverType}
 		}
 
+		if location != "" {
+			options.Location = &hcloud.Location{Name: location}
+		}
+
 		image, err := client.Upload(ctx, options)
 		if err != nil {
 			return fmt.Errorf("failed to upload the image: %w", err)
@@ -148,4 +154,10 @@ func init() {
 	uploadCmd.Flags().String(uploadFlagDescription, "", "Description for the resulting image")
 
 	uploadCmd.Flags().StringToString(uploadFlagLabels, map[string]string{}, "Labels for the resulting image")
+
+	uploadCmd.Flags().String(uploadFlagLocation, "", "Datacenter location for the temporary server [default: fsn1, choices: fsn1, nbg1, hel1, ash, hil, sin]")
+	_ = uploadCmd.RegisterFlagCompletionFunc(
+		uploadFlagLocation,
+		cobra.FixedCompletions([]string{"fsn1", "nbg1", "hel1", "ash", "hil", "sin"}, cobra.ShellCompDirectiveNoFileComp),
+	)
 }

--- a/docs/reference/cli/hcloud-upload-image_upload.md
+++ b/docs/reference/cli/hcloud-upload-image_upload.md
@@ -41,6 +41,7 @@ hcloud-upload-image upload (--image-path=<local-path> | --image-url=<url>) --arc
       --image-path string       Local path to the disk image that should be uploaded
       --image-url string        Remote URL of the disk image that should be uploaded
       --labels stringToString   Labels for the resulting image (default [])
+      --location string         Datacenter location for the temporary server [default: fsn1, choices: fsn1, nbg1, hel1, ash, hil, sin]
       --server-type string      Explicitly use this server type to generate the image. Mutually exclusive with --architecture.
 ```
 

--- a/hcloudimages/doc_test.go
+++ b/hcloudimages/doc_test.go
@@ -24,6 +24,7 @@ func ExampleClient_Upload() {
 		ImageURL:         imageURL,
 		ImageCompression: hcloudimages.CompressionBZ2,
 		Architecture:     hcloud.ArchitectureX86,
+		Location:         &hcloud.Location{Name: "nbg1"}, // Optional: defaults to fsn1
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Allow users to specify which Hetzner datacenter location to use for the temporary server during image upload. Defaults to fsn1 for backward compatibility.

Available locations: fsn1, nbg1, hel1, ash, hil, sin

Implements: #142