### PR TITLE
feat!: new write-to-disk command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ var (
 
 // The pre-authenticated client. Set in the root command PersistentPreRun
 var client *hcloudimages.Client
+var hcloudclient *hcloud.Client
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -95,7 +96,8 @@ func initClient(cmd *cobra.Command, _ []string) {
 		opts = append(opts, hcloud.WithDebugWriter(os.Stderr))
 	}
 
-	client = hcloudimages.NewClient(hcloud.NewClient(opts...))
+	hcloudclient = hcloud.NewClient(opts...)
+	client = hcloudimages.NewClient(hcloudclient)
 }
 
 func Execute() {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -3,9 +3,6 @@ package cmd
 import (
 	_ "embed"
 	"fmt"
-	"net/http"
-	"net/url"
-	"os"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
@@ -15,10 +12,6 @@ import (
 )
 
 const (
-	uploadFlagImageURL     = "image-url"
-	uploadFlagImagePath    = "image-path"
-	uploadFlagCompression  = "compression"
-	uploadFlagFormat       = "format"
 	uploadFlagArchitecture = "architecture"
 	uploadFlagServerType   = "server-type"
 	uploadFlagDescription  = "description"
@@ -27,13 +20,13 @@ const (
 )
 
 //go:embed upload.md
-var longDescription string
+var uploadLongDescription string
 
 // uploadCmd represents the upload command
 var uploadCmd = &cobra.Command{
 	Use:   "upload (--image-path=<local-path> | --image-url=<url>) --architecture=<x86|arm>",
 	Short: "Upload the specified disk image into your Hetzner Cloud project.",
-	Long:  longDescription,
+	Long:  uploadLongDescription,
 	Example: `  hcloud-upload-image upload --image-path /home/you/images/custom-linux-image-x86.bz2 --architecture x86 --compression bz2 --description "My super duper custom linux"
   hcloud-upload-image upload --image-url https://examples.com/image-arm.raw --architecture arm --labels foo=bar,version=latest
   hcloud-upload-image upload --image-url https://examples.com/image-x86.qcow2 --architecture x86 --format qcow2`,
@@ -47,10 +40,11 @@ var uploadCmd = &cobra.Command{
 		ctx := cmd.Context()
 		logger := contextlogger.From(ctx)
 
-		imageURLString, _ := cmd.Flags().GetString(uploadFlagImageURL)
-		imagePathString, _ := cmd.Flags().GetString(uploadFlagImagePath)
-		imageCompression, _ := cmd.Flags().GetString(uploadFlagCompression)
-		imageFormat, _ := cmd.Flags().GetString(uploadFlagFormat)
+		writeOptions, err := parseAndValidateWriteOptions(ctx, cmd.Flags())
+		if err != nil {
+			return err
+		}
+
 		architecture, _ := cmd.Flags().GetString(uploadFlagArchitecture)
 		serverType, _ := cmd.Flags().GetString(uploadFlagServerType)
 		description, _ := cmd.Flags().GetString(uploadFlagDescription)
@@ -58,44 +52,9 @@ var uploadCmd = &cobra.Command{
 		location, _ := cmd.Flags().GetString(uploadFlagLocation)
 
 		options := hcloudimages.UploadOptions{
-			ImageCompression: hcloudimages.Compression(imageCompression),
-			ImageFormat:      hcloudimages.Format(imageFormat),
-			Description:      hcloud.Ptr(description),
-			Labels:           labels,
-		}
-
-		if imageURLString != "" {
-			imageURL, err := url.Parse(imageURLString)
-			if err != nil {
-				return fmt.Errorf("unable to parse url from --%s=%q: %w", uploadFlagImageURL, imageURLString, err)
-			}
-
-			// Check for image size
-			resp, err := http.Head(imageURL.String())
-			switch {
-			case err != nil:
-				logger.DebugContext(ctx, "failed to check for file size, error on request", "err", err)
-			case resp.ContentLength == -1:
-				logger.DebugContext(ctx, "failed to check for file size, server did not set the Content-Length", "err", err)
-			default:
-				options.ImageSize = resp.ContentLength
-			}
-
-			options.ImageURL = imageURL
-		} else if imagePathString != "" {
-			stat, err := os.Stat(imagePathString)
-			if err != nil {
-				logger.DebugContext(ctx, "failed to check for file size, error on stat", "err", err)
-			} else {
-				options.ImageSize = stat.Size()
-			}
-
-			imageFile, err := os.Open(imagePathString)
-			if err != nil {
-				return fmt.Errorf("unable to read file from --%s=%q: %w", uploadFlagImagePath, imagePathString, err)
-			}
-
-			options.ImageReader = imageFile
+			WriteOptions: writeOptions,
+			Description:  hcloud.Ptr(description),
+			Labels:       labels,
 		}
 
 		if architecture != "" {
@@ -122,22 +81,7 @@ var uploadCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(uploadCmd)
 
-	uploadCmd.Flags().String(uploadFlagImageURL, "", "Remote URL of the disk image that should be uploaded")
-	uploadCmd.Flags().String(uploadFlagImagePath, "", "Local path to the disk image that should be uploaded")
-	uploadCmd.MarkFlagsMutuallyExclusive(uploadFlagImageURL, uploadFlagImagePath)
-	uploadCmd.MarkFlagsOneRequired(uploadFlagImageURL, uploadFlagImagePath)
-
-	uploadCmd.Flags().String(uploadFlagCompression, "", "Type of compression that was used on the disk image [choices: bz2, xz, zstd]")
-	_ = uploadCmd.RegisterFlagCompletionFunc(
-		uploadFlagCompression,
-		cobra.FixedCompletions([]string{string(hcloudimages.CompressionBZ2), string(hcloudimages.CompressionXZ), string(hcloudimages.CompressionZSTD)}, cobra.ShellCompDirectiveNoFileComp),
-	)
-
-	uploadCmd.Flags().String(uploadFlagFormat, "", "Format of the image. [default: raw, choices: qcow2]")
-	_ = uploadCmd.RegisterFlagCompletionFunc(
-		uploadFlagFormat,
-		cobra.FixedCompletions([]string{string(hcloudimages.FormatQCOW2)}, cobra.ShellCompDirectiveNoFileComp),
-	)
+	registerWriteOptions(uploadCmd)
 
 	uploadCmd.Flags().String(uploadFlagArchitecture, "", "CPU architecture of the disk image [choices: x86, arm]")
 	_ = uploadCmd.RegisterFlagCompletionFunc(

--- a/cmd/write-to-disk.go
+++ b/cmd/write-to-disk.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/apricote/hcloud-upload-image/hcloudimages"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+)
+
+const (
+	writeFlagImageURL    = "image-url"
+	writeFlagImagePath   = "image-path"
+	writeFlagCompression = "compression"
+	writeFlagFormat      = "format"
+	writeFlagServer      = "server"
+)
+
+func registerWriteOptions(cmd *cobra.Command) {
+	cmd.Flags().String(writeFlagImageURL, "", "Remote URL of the disk image")
+	cmd.Flags().String(writeFlagImagePath, "", "Local path to the disk image")
+	cmd.MarkFlagsMutuallyExclusive(writeFlagImageURL, writeFlagImagePath)
+	cmd.MarkFlagsOneRequired(writeFlagImageURL, writeFlagImagePath)
+
+	cmd.Flags().String(writeFlagCompression, "", "Type of compression that was used on the disk image [choices: bz2, xz, zstd]")
+	_ = cmd.RegisterFlagCompletionFunc(
+		writeFlagCompression,
+		cobra.FixedCompletions([]string{string(hcloudimages.CompressionBZ2), string(hcloudimages.CompressionXZ), string(hcloudimages.CompressionZSTD)}, cobra.ShellCompDirectiveNoFileComp),
+	)
+
+	cmd.Flags().String(writeFlagFormat, "", "Format of the disk image. [default: raw, choices: qcow2]")
+	_ = cmd.RegisterFlagCompletionFunc(
+		writeFlagFormat,
+		cobra.FixedCompletions([]string{string(hcloudimages.FormatQCOW2)}, cobra.ShellCompDirectiveNoFileComp),
+	)
+}
+
+func parseAndValidateWriteOptions(ctx context.Context, flags *pflag.FlagSet) (hcloudimages.WriteOptions, error) {
+	logger := contextlogger.From(ctx)
+
+	imageURLString, _ := flags.GetString(writeFlagImageURL)
+	imagePathString, _ := flags.GetString(writeFlagImagePath)
+	imageCompression, _ := flags.GetString(writeFlagCompression)
+	imageFormat, _ := flags.GetString(writeFlagFormat)
+
+	options := hcloudimages.WriteOptions{
+		ImageCompression: hcloudimages.Compression(imageCompression),
+		ImageFormat:      hcloudimages.Format(imageFormat),
+	}
+
+	if imageURLString != "" {
+		imageURL, err := url.Parse(imageURLString)
+		if err != nil {
+			return hcloudimages.WriteOptions{}, fmt.Errorf("unable to parse url from --%s=%q: %w", writeFlagImageURL, imageURLString, err)
+		}
+
+		// Check for image size
+		resp, err := http.Head(imageURL.String())
+		switch {
+		case err != nil:
+			logger.DebugContext(ctx, "failed to check for file size, error on request", "err", err)
+		case resp.ContentLength == -1:
+			logger.DebugContext(ctx, "failed to check for file size, server did not set the Content-Length", "err", err)
+		default:
+			options.ImageSize = resp.ContentLength
+		}
+		_ = resp.Body.Close()
+
+		options.ImageURL = imageURL
+	} else if imagePathString != "" {
+		stat, err := os.Stat(imagePathString)
+		if err != nil {
+			logger.DebugContext(ctx, "failed to check for file size, error on stat", "err", err)
+		} else {
+			options.ImageSize = stat.Size()
+		}
+
+		imageFile, err := os.Open(imagePathString)
+		if err != nil {
+			return hcloudimages.WriteOptions{}, fmt.Errorf("unable to read file from --%s=%q: %w", writeFlagImagePath, imagePathString, err)
+		}
+
+		options.ImageReader = imageFile
+	}
+
+	return options, nil
+}
+
+//go:embed write-to-disk.md
+var writeToDiskLongDescription string
+
+// writeToDiskCmd represents the write-to-disk command
+var writeToDiskCmd = &cobra.Command{
+	Use:   "write-to-disk (--image-path=<local-path> | --image-url=<url>) --server <id-or-name>",
+	Short: "Write the specified disk image to the root disk of the specified server.",
+	Long:  writeToDiskLongDescription,
+	Example: `  hcloud-upload-image write-to-disk --image-path /home/you/images/custom-linux-image-x86.bz2 --compression bz2 --server my-server
+  hcloud-upload-image write-to-disk --image-url https://examples.com/image-arm.raw --server my-arm-server
+  hcloud-upload-image write-to-disk --image-url https://examples.com/image-x86.qcow2 --format qcow2 --server my-x86-server`,
+	DisableAutoGenTag: true,
+
+	GroupID: "primary",
+
+	PreRun: initClient,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		logger := contextlogger.From(ctx)
+
+		options, err := parseAndValidateWriteOptions(ctx, cmd.Flags())
+		if err != nil {
+			return err
+		}
+
+		serverIDOrName, _ := cmd.Flags().GetString(writeFlagServer)
+		options.Server, _, err = hcloudclient.Server.Get(ctx, serverIDOrName)
+		if err != nil {
+			return fmt.Errorf("could not get server %q: %w", serverIDOrName, err)
+		}
+		if options.Server == nil {
+			return fmt.Errorf("server %q not found", serverIDOrName)
+		}
+
+		err = client.WriteToDisk(ctx, options)
+		if err != nil {
+			return fmt.Errorf("failed to write the image: %w", err)
+		}
+
+		logger.InfoContext(ctx, "Successfully wrote the image!")
+
+		return nil
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(writeToDiskCmd)
+
+	registerWriteOptions(writeToDiskCmd)
+
+	writeToDiskCmd.Flags().String(writeFlagServer, "", "ID or name of target server")
+	_ = writeToDiskCmd.MarkFlagRequired(writeFlagServer)
+	_ = writeToDiskCmd.RegisterFlagCompletionFunc(
+		writeFlagServer,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+			servers, err := hcloudclient.Server.AllWithOpts(cmd.Context(), hcloud.ServerListOpts{})
+			if err != nil {
+				return []cobra.Completion{}, cobra.ShellCompDirectiveError
+			}
+
+			serverNames := make([]string, len(servers))
+			for i, server := range servers {
+				serverNames[i] = server.Name
+			}
+
+			return serverNames, cobra.ShellCompDirectiveNoFileComp
+		},
+	)
+}

--- a/cmd/write-to-disk.md
+++ b/cmd/write-to-disk.md
@@ -1,0 +1,12 @@
+This command writes the specified image to the target servers root disk. Think of
+it as a one-off "upload".
+
+#### Image Size
+
+The image size for raw disk images is only limited by the servers root disk.
+
+The image size for qcow2 images is limited to the rescue systems root disk.
+This is currently a memory-backed file system with **960 MB** of space. A qcow2
+image not be larger than this size, or the process will error. There is a
+warning being logged if hcloud-upload-image can detect that your file is larger
+than this size.

--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ buildGoModule rec {
       (builtins.readFile ./internal/version/version.go));
 
   src = ./.;
-  vendorHash = "sha256-CVdhf8pDBANzlZzaqaGPv+vUTOQB/K+LEIh8tZUTSnA=";
+  vendorHash = "sha256-YgiSTnCg+7RuSxp0NDNn7QamV7HgdQY+DrbEIv68eJw=";
   env.GOWORK = "off";
   subPackages = ["."];
   goSum = ./go.sum; # make sure to rebuild

--- a/docs/reference/cli/hcloud-upload-image.md
+++ b/docs/reference/cli/hcloud-upload-image.md
@@ -17,4 +17,5 @@ Manage custom OS images on Hetzner Cloud.
 
 * [hcloud-upload-image cleanup](hcloud-upload-image_cleanup.md)	 - Remove any temporary resources that were left over
 * [hcloud-upload-image upload](hcloud-upload-image_upload.md)	 - Upload the specified disk image into your Hetzner Cloud project.
+* [hcloud-upload-image write-to-disk](hcloud-upload-image_write-to-disk.md)	 - Write the specified disk image to the root disk of the specified server.
 

--- a/docs/reference/cli/hcloud-upload-image_upload.md
+++ b/docs/reference/cli/hcloud-upload-image_upload.md
@@ -36,10 +36,10 @@ hcloud-upload-image upload (--image-path=<local-path> | --image-url=<url>) --arc
       --architecture string     CPU architecture of the disk image [choices: x86, arm]
       --compression string      Type of compression that was used on the disk image [choices: bz2, xz, zstd]
       --description string      Description for the resulting image
-      --format string           Format of the image. [default: raw, choices: qcow2]
+      --format string           Format of the disk image. [default: raw, choices: qcow2]
   -h, --help                    help for upload
-      --image-path string       Local path to the disk image that should be uploaded
-      --image-url string        Remote URL of the disk image that should be uploaded
+      --image-path string       Local path to the disk image
+      --image-url string        Remote URL of the disk image
       --labels stringToString   Labels for the resulting image (default [])
       --location string         Datacenter location for the temporary server [default: fsn1, choices: fsn1, nbg1, hel1, ash, hil, sin]
       --server-type string      Explicitly use this server type to generate the image. Mutually exclusive with --architecture.

--- a/docs/reference/cli/hcloud-upload-image_write-to-disk.md
+++ b/docs/reference/cli/hcloud-upload-image_write-to-disk.md
@@ -1,0 +1,53 @@
+## hcloud-upload-image write-to-disk
+
+Write the specified disk image to the root disk of the specified server.
+
+### Synopsis
+
+This command writes the specified image to the target servers root disk. Think of
+it as a one-off "upload".
+
+#### Image Size
+
+The image size for raw disk images is only limited by the servers root disk.
+
+The image size for qcow2 images is limited to the rescue systems root disk.
+This is currently a memory-backed file system with **960 MB** of space. A qcow2
+image not be larger than this size, or the process will error. There is a
+warning being logged if hcloud-upload-image can detect that your file is larger
+than this size.
+
+
+```
+hcloud-upload-image write-to-disk (--image-path=<local-path> | --image-url=<url>) --server <id-or-name> [flags]
+```
+
+### Examples
+
+```
+  hcloud-upload-image write-to-disk --image-path /home/you/images/custom-linux-image-x86.bz2 --compression bz2 --server my-server
+  hcloud-upload-image write-to-disk --image-url https://examples.com/image-arm.raw --server my-arm-server
+  hcloud-upload-image write-to-disk --image-url https://examples.com/image-x86.qcow2 --format qcow2 --server my-x86-server
+```
+
+### Options
+
+```
+      --compression string   Type of compression that was used on the disk image [choices: bz2, xz, zstd]
+      --format string        Format of the disk image. [default: raw, choices: qcow2]
+  -h, --help                 help for write-to-disk
+      --image-path string    Local path to the disk image
+      --image-url string     Remote URL of the disk image
+      --server string        ID or name of target server
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose count   verbose debug output, can be specified up to 2 times
+```
+
+### SEE ALSO
+
+* [hcloud-upload-image](hcloud-upload-image.md)	 - Manage custom OS images on Hetzner Cloud.
+

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0
 	github.com/hetznercloud/hcloud-go/v2 v2.40.0
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 )
 
 require (
@@ -21,7 +22,6 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.51.0 // indirect

--- a/hcloudimages/client.go
+++ b/hcloudimages/client.go
@@ -49,7 +49,7 @@ var (
 	rescueSystemRootDiskSizeMB int64 = 960
 )
 
-type UploadOptions struct {
+type WriteOptions struct {
 	// ImageURL must be publicly available. The instance will download the image from this endpoint.
 	ImageURL *url.URL
 
@@ -65,9 +65,12 @@ type UploadOptions struct {
 	// Can be optionally set to make the client validate that the image can be written to the server.
 	ImageSize int64
 
-	// Possible future additions:
-	// ImageSignatureVerification
-	// ImageLocalPath
+	// Server the image is written to.
+	Server *hcloud.Server
+}
+
+type UploadOptions struct {
+	WriteOptions
 
 	// Architecture should match the architecture of the Image. This decides if the Snapshot can later be
 	// used with [hcloud.ArchitectureX86] or [hcloud.ArchitectureARM] servers.
@@ -122,7 +125,7 @@ const (
 	// FormatQCOW2 allows to upload images in the qcow2 format directly.
 	//
 	// The qcow2 image must fit on the disk available in the rescue system. "qemu-img dd", which is used to convert
-	// qcow2 to raw, requires a file as an input. If [UploadOption.ImageSize] is set and FormatQCOW2 is used, there is a
+	// qcow2 to raw, requires a file as an input. If [WriteOptions.ImageSize] is set and FormatQCOW2 is used, there is a
 	// warning message displayed if there is a high probability of issues.
 	FormatQCOW2 Format = "qcow2"
 )
@@ -138,27 +141,89 @@ type Client struct {
 	c *hcloud.Client
 }
 
-// Upload the specified image into a snapshot on Hetzner Cloud.
+// WriteToDisk writes the specified image onto the root disk of an existing server on Hetzner Cloud.
 //
-// As the Hetzner Cloud API has no direct way to upload images, we create a temporary server,
-// overwrite the root disk and take a snapshot of that disk instead.
-//
-// The temporary server costs money. If the upload fails, we might be unable to delete the server. Check out
-// CleanupTempResources for a helper in this case.
-func (s *Client) Upload(ctx context.Context, options UploadOptions) (*hcloud.Image, error) {
-	logger := contextlogger.From(ctx).With(
-		"library", "hcloudimages",
-		"method", "upload",
-	)
-
+// The server will be rebooted multiple times and any existing data is lost.
+func (s *Client) WriteToDisk(ctx context.Context, options WriteOptions) error {
 	id, err := randomid.Generate()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	logger = logger.With("run-id", id)
-	// For simplicity, we use the name random name for SSH Key + Server
+
+	logger := contextlogger.From(ctx).With(
+		"library", "hcloudimages",
+		"method", "write",
+		"run-id", id,
+	)
+	ctx = contextlogger.New(ctx, logger)
+
 	resourceName := resourcePrefix + id
-	labels := labelutil.Merge(DefaultLabels, options.Labels)
+
+	// 1. Create SSH Key
+	key, privateKey, keyCleanup, err := s.generateSSHKey(ctx, 1, resourceName, DefaultLabels)
+	if err != nil {
+		return err
+	}
+	defer keyCleanup(false)
+
+	// 2. Power off Server
+	logger.InfoContext(ctx, "# Step 2: Shutting down server")
+	powerOffAction, _, err := s.c.Server.Poweroff(ctx, options.Server)
+	if err != nil {
+		return fmt.Errorf("stopping the server failed: %w", err)
+	}
+
+	logger.DebugContext(ctx, "power off requested, waiting on action")
+
+	err = s.c.Action.WaitFor(ctx, powerOffAction)
+	if err != nil {
+		return fmt.Errorf("stopping the server failed: %w", err)
+	}
+	logger.DebugContext(ctx, "action finished, server is powered off")
+
+	// 3-8
+	return s.write(ctx, options, 3, key, privateKey)
+}
+
+func (s *Client) generateSSHKey(ctx context.Context, step int, resourceName string, labels map[string]string) (*hcloud.SSHKey, []byte, func(bool), error) {
+	logger := contextlogger.From(ctx)
+
+	// 1. Create SSH Key
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Generating SSH Key", step))
+	privateKey, publicKey, err := sshutil.GenerateKeyPair()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to generate temporary ssh key pair: %w", err)
+	}
+
+	key, _, err := s.c.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
+		Name:      resourceName,
+		PublicKey: string(publicKey),
+		Labels:    labels,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to submit temporary ssh key to API: %w", err)
+	}
+	logger.DebugContext(ctx, "Uploaded ssh key", "ssh-key-id", key.ID)
+	return key, privateKey, func(skipCleanup bool) {
+		// Cleanup SSH Key
+		if skipCleanup {
+			logger.InfoContext(ctx, "Cleanup: Skipping cleanup of temporary ssh key")
+			return
+		}
+
+		logger.InfoContext(ctx, "Cleanup: Deleting temporary ssh key")
+
+		_, err := s.c.SSHKey.Delete(ctx, key)
+		if err != nil {
+			logger.WarnContext(ctx, "Cleanup: ssh key could not be deleted", "error", err)
+			// TODO
+		}
+	}, nil
+}
+
+// write is the internal utility function to actually write the image to a root disk. It expects a powered off server and returns a powered off server.
+func (s *Client) write(ctx context.Context, options WriteOptions, initialStep int, key *hcloud.SSHKey, privateKey []byte) error {
+	logger := contextlogger.From(ctx)
 
 	// 0. Validations
 	if options.ImageFormat == FormatQCOW2 && options.ImageSize > 0 {
@@ -173,37 +238,140 @@ func (s *Client) Upload(ctx context.Context, options UploadOptions) (*hcloud.Ima
 		}
 	}
 
-	// 1. Create SSH Key
-	logger.InfoContext(ctx, "# Step 1: Generating SSH Key")
-	privateKey, publicKey, err := sshutil.GenerateKeyPair()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate temporary ssh key pair: %w", err)
-	}
-
-	key, _, err := s.c.SSHKey.Create(ctx, hcloud.SSHKeyCreateOpts{
-		Name:      resourceName,
-		PublicKey: string(publicKey),
-		Labels:    labels,
+	// 3. Activate Rescue System
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Activating Rescue System", initialStep+0))
+	enableRescueResult, _, err := s.c.Server.EnableRescue(ctx, options.Server, hcloud.ServerEnableRescueOpts{
+		Type:    defaultRescueType,
+		SSHKeys: []*hcloud.SSHKey{key},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to submit temporary ssh key to API: %w", err)
+		return fmt.Errorf("enabling the rescue system on the temporary server failed: %w", err)
 	}
-	logger.DebugContext(ctx, "Uploaded ssh key", "ssh-key-id", key.ID)
-	defer func() {
-		// Cleanup SSH Key
-		if options.DebugSkipResourceCleanup {
-			logger.InfoContext(ctx, "Cleanup: Skipping cleanup of temporary ssh key")
-			return
-		}
 
-		logger.InfoContext(ctx, "Cleanup: Deleting temporary ssh key")
+	logger.DebugContext(ctx, "rescue system requested, waiting on action")
 
-		_, err := s.c.SSHKey.Delete(ctx, key)
-		if err != nil {
-			logger.WarnContext(ctx, "Cleanup: ssh key could not be deleted", "error", err)
-			// TODO
-		}
-	}()
+	err = s.c.Action.WaitFor(ctx, enableRescueResult.Action)
+	if err != nil {
+		return fmt.Errorf("enabling the rescue system on the temporary server failed: %w", err)
+	}
+	logger.DebugContext(ctx, "action finished, rescue system enabled")
+
+	// 4. Boot Server
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Booting Server", initialStep+1))
+	powerOnAction, _, err := s.c.Server.Poweron(ctx, options.Server)
+	if err != nil {
+		return fmt.Errorf("starting the temporary server failed: %w", err)
+	}
+
+	logger.DebugContext(ctx, "boot requested, waiting on action")
+
+	err = s.c.Action.WaitFor(ctx, powerOnAction)
+	if err != nil {
+		return fmt.Errorf("starting the temporary server failed: %w", err)
+	}
+	logger.DebugContext(ctx, "action finished, server is booting")
+
+	// 5. Open SSH Session
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Opening SSH Connection", initialStep+2))
+	signer, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		return fmt.Errorf("parsing the automatically generated temporary private key failed: %w", err)
+	}
+
+	sshClientConfig := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		// There is no way to get the host key of the rescue system beforehand
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         defaultSSHDialTimeout,
+	}
+
+	// the server needs some time until its properly started and ssh is available
+	var sshClient *ssh.Client
+
+	err = control.Retry(
+		contextlogger.New(ctx, logger.With("operation", "ssh")),
+		100, // ~ 3 minutes
+		func() error {
+			var err error
+			logger.DebugContext(ctx, "trying to connect to server", "ip", options.Server.PublicNet.IPv4.IP)
+			sshClient, err = ssh.Dial("tcp", options.Server.PublicNet.IPv4.IP.String()+":ssh", sshClientConfig)
+			return err
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to ssh into temporary server: %w", err)
+	}
+	defer func() { _ = sshClient.Close() }()
+
+	// 6. Wipe existing disk, to avoid storing any bytes from it in the snapshot
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Cleaning existing disk", initialStep+3))
+
+	output, err := sshsession.Run(sshClient, "blkdiscard --force /dev/sda", nil)
+	logger.DebugContext(ctx, string(output))
+	if err != nil {
+		return fmt.Errorf("failed to clean existing disk: %w", err)
+	}
+
+	// 7. SSH On Server: Download Image, Decompress, Write to Root Disk
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Downloading image and writing to disk", initialStep+4))
+
+	cmd, err := assembleCommand(options)
+	if err != nil {
+		return err
+	}
+
+	logger.DebugContext(ctx, "running download, decompress and write to disk command", "cmd", cmd)
+
+	output, err = sshsession.Run(sshClient, cmd, options.ImageReader)
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Finished writing image to disk", initialStep+4))
+	logger.DebugContext(ctx, string(output))
+	if err != nil {
+		return fmt.Errorf("failed to download and write the image: %w", err)
+	}
+
+	// 8. SSH On Server: Shutdown
+	logger.InfoContext(ctx, fmt.Sprintf("# Step %d: Shutting down server", initialStep+5))
+	_, err = sshsession.Run(sshClient, "shutdown now", nil)
+	if err != nil {
+		// TODO Verify if shutdown error, otherwise return
+		logger.WarnContext(ctx, "shutdown returned error", "err", err)
+	}
+
+	return nil
+}
+
+// Upload the specified image into a snapshot on Hetzner Cloud.
+//
+// As the Hetzner Cloud API has no direct way to upload images, we create a temporary server,
+// overwrite the root disk and take a snapshot of that disk instead.
+//
+// The temporary server costs money. If the upload fails, we might be unable to delete the server. Check out
+// CleanupTempResources for a helper in this case.
+func (s *Client) Upload(ctx context.Context, options UploadOptions) (*hcloud.Image, error) {
+	id, err := randomid.Generate()
+	if err != nil {
+		return nil, err
+	}
+
+	logger := contextlogger.From(ctx).With(
+		"library", "hcloudimages",
+		"method", "upload",
+		"run-id", id,
+	)
+	ctx = contextlogger.New(ctx, logger)
+
+	// For simplicity, we use the same random name for SSH Key + Server
+	resourceName := resourcePrefix + id
+	labels := labelutil.Merge(DefaultLabels, options.Labels)
+
+	key, privateKey, keyCleanup, err := s.generateSSHKey(ctx, 1, resourceName, labels)
+	if err != nil {
+		return nil, err
+	}
+	defer keyCleanup(options.DebugSkipResourceCleanup)
 
 	// 2. Create Server
 	logger.InfoContext(ctx, "# Step 2: Creating Server")
@@ -255,7 +423,7 @@ func (s *Client) Upload(ctx context.Context, options UploadOptions) (*hcloud.Ima
 	}
 	logger.DebugContext(ctx, "actions finished")
 
-	server := serverCreateResult.Server
+	options.Server = serverCreateResult.Server
 	defer func() {
 		// Cleanup Server
 		if options.DebugSkipResourceCleanup {
@@ -265,117 +433,21 @@ func (s *Client) Upload(ctx context.Context, options UploadOptions) (*hcloud.Ima
 
 		logger.InfoContext(ctx, "Cleanup: Deleting temporary server")
 
-		_, _, err := s.c.Server.DeleteWithResult(ctx, server)
+		_, _, err := s.c.Server.DeleteWithResult(ctx, options.Server)
 		if err != nil {
 			logger.WarnContext(ctx, "Cleanup: server could not be deleted", "error", err)
 		}
 	}()
 
-	// 3. Activate Rescue System
-	logger.InfoContext(ctx, "# Step 3: Activating Rescue System")
-	enableRescueResult, _, err := s.c.Server.EnableRescue(ctx, server, hcloud.ServerEnableRescueOpts{
-		Type:    defaultRescueType,
-		SSHKeys: []*hcloud.SSHKey{key},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("enabling the rescue system on the temporary server failed: %w", err)
-	}
-
-	logger.DebugContext(ctx, "rescue system requested, waiting on action")
-
-	err = s.c.Action.WaitFor(ctx, enableRescueResult.Action)
-	if err != nil {
-		return nil, fmt.Errorf("enabling the rescue system on the temporary server failed: %w", err)
-	}
-	logger.DebugContext(ctx, "action finished, rescue system enabled")
-
-	// 4. Boot Server
-	logger.InfoContext(ctx, "# Step 4: Booting Server")
-	powerOnAction, _, err := s.c.Server.Poweron(ctx, server)
-	if err != nil {
-		return nil, fmt.Errorf("starting the temporary server failed: %w", err)
-	}
-
-	logger.DebugContext(ctx, "boot requested, waiting on action")
-
-	err = s.c.Action.WaitFor(ctx, powerOnAction)
-	if err != nil {
-		return nil, fmt.Errorf("starting the temporary server failed: %w", err)
-	}
-	logger.DebugContext(ctx, "action finished, server is booting")
-
-	// 5. Open SSH Session
-	logger.InfoContext(ctx, "# Step 5: Opening SSH Connection")
-	signer, err := ssh.ParsePrivateKey(privateKey)
-	if err != nil {
-		return nil, fmt.Errorf("parsing the automatically generated temporary private key failed: %w", err)
-	}
-
-	sshClientConfig := &ssh.ClientConfig{
-		User: "root",
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		// There is no way to get the host key of the rescue system beforehand
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         defaultSSHDialTimeout,
-	}
-
-	// the server needs some time until its properly started and ssh is available
-	var sshClient *ssh.Client
-
-	err = control.Retry(
-		contextlogger.New(ctx, logger.With("operation", "ssh")),
-		100, // ~ 3 minutes
-		func() error {
-			var err error
-			logger.DebugContext(ctx, "trying to connect to server", "ip", server.PublicNet.IPv4.IP)
-			sshClient, err = ssh.Dial("tcp", server.PublicNet.IPv4.IP.String()+":ssh", sshClientConfig)
-			return err
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to ssh into temporary server: %w", err)
-	}
-	defer func() { _ = sshClient.Close() }()
-
-	// 6. Wipe existing disk, to avoid storing any bytes from it in the snapshot
-	logger.InfoContext(ctx, "# Step 6: Cleaning existing disk")
-
-	output, err := sshsession.Run(sshClient, "blkdiscard /dev/sda", nil)
-	logger.DebugContext(ctx, string(output))
-	if err != nil {
-		return nil, fmt.Errorf("failed to clean existing disk: %w", err)
-	}
-
-	// 7. SSH On Server: Download Image, Decompress, Write to Root Disk
-	logger.InfoContext(ctx, "# Step 7: Downloading image and writing to disk")
-
-	cmd, err := assembleCommand(options)
+	// Steps 3-8
+	err = s.write(ctx, options.WriteOptions, 3, key, privateKey)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.DebugContext(ctx, "running download, decompress and write to disk command", "cmd", cmd)
-
-	output, err = sshsession.Run(sshClient, cmd, options.ImageReader)
-	logger.InfoContext(ctx, "# Step 7: Finished writing image to disk")
-	logger.DebugContext(ctx, string(output))
-	if err != nil {
-		return nil, fmt.Errorf("failed to download and write the image: %w", err)
-	}
-
-	// 8. SSH On Server: Shutdown
-	logger.InfoContext(ctx, "# Step 8: Shutting down server")
-	_, err = sshsession.Run(sshClient, "shutdown now", nil)
-	if err != nil {
-		// TODO Verify if shutdown error, otherwise return
-		logger.WarnContext(ctx, "shutdown returned error", "err", err)
-	}
-
 	// 9. Create Image from Server
 	logger.InfoContext(ctx, "# Step 9: Creating Image")
-	createImageResult, _, err := s.c.Server.CreateImage(ctx, server, &hcloud.ServerCreateImageOpts{
+	createImageResult, _, err := s.c.Server.CreateImage(ctx, options.Server, &hcloud.ServerCreateImageOpts{
 		Type:        hcloud.ImageTypeSnapshot,
 		Description: options.Description,
 		Labels:      labels,
@@ -520,7 +592,7 @@ func (s *Client) cleanupTempSSHKeys(ctx context.Context, logger *slog.Logger, se
 	return nil
 }
 
-func assembleCommand(options UploadOptions) (string, error) {
+func assembleCommand(options WriteOptions) (string, error) {
 	// Make sure that we fail early, ie. if the image url does not work
 	cmd := "set -euo pipefail && "
 

--- a/hcloudimages/client_test.go
+++ b/hcloudimages/client_test.go
@@ -17,32 +17,32 @@ func mustParseURL(s string) *url.URL {
 func TestAssembleCommand(t *testing.T) {
 	tests := []struct {
 		name    string
-		options UploadOptions
+		options WriteOptions
 		want    string
 		wantErr bool
 	}{
 		{
 			name:    "local raw",
-			options: UploadOptions{},
+			options: WriteOptions{},
 			want:    "bash -c 'set -euo pipefail && dd of=/dev/sda bs=4M conv=sparse && sync'",
 		},
 		{
 			name: "remote raw",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageURL: mustParseURL("https://example.com/image.xz"),
 			},
 			want: "bash -c 'set -euo pipefail && wget --no-verbose -O - \"https://example.com/image.xz\" | dd of=/dev/sda bs=4M conv=sparse && sync'",
 		},
 		{
 			name: "local xz",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageCompression: CompressionXZ,
 			},
 			want: "bash -c 'set -euo pipefail && xz -cd | dd of=/dev/sda bs=4M conv=sparse && sync'",
 		},
 		{
 			name: "remote xz",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageURL:         mustParseURL("https://example.com/image.xz"),
 				ImageCompression: CompressionXZ,
 			},
@@ -50,14 +50,14 @@ func TestAssembleCommand(t *testing.T) {
 		},
 		{
 			name: "local zstd",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageCompression: CompressionZSTD,
 			},
 			want: "bash -c 'set -euo pipefail && zstd -cd | dd of=/dev/sda bs=4M conv=sparse && sync'",
 		},
 		{
 			name: "remote zstd",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageURL:         mustParseURL("https://example.com/image.zst"),
 				ImageCompression: CompressionZSTD,
 			},
@@ -65,14 +65,14 @@ func TestAssembleCommand(t *testing.T) {
 		},
 		{
 			name: "local bz2",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageCompression: CompressionBZ2,
 			},
 			want: "bash -c 'set -euo pipefail && bzip2 -cd | dd of=/dev/sda bs=4M conv=sparse && sync'",
 		},
 		{
 			name: "remote bz2",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageURL:         mustParseURL("https://example.com/image.bz2"),
 				ImageCompression: CompressionBZ2,
 			},
@@ -80,14 +80,14 @@ func TestAssembleCommand(t *testing.T) {
 		},
 		{
 			name: "local qcow2",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageFormat: FormatQCOW2,
 			},
 			want: "bash -c 'set -euo pipefail && tee image.qcow2 > /dev/null && qemu-img dd -f qcow2 -O raw if=image.qcow2 of=/dev/sda bs=4M && sync'",
 		},
 		{
 			name: "remote qcow2",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageURL:    mustParseURL("https://example.com/image.qcow2"),
 				ImageFormat: FormatQCOW2,
 			},
@@ -96,7 +96,7 @@ func TestAssembleCommand(t *testing.T) {
 
 		{
 			name: "unknown compression",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageCompression: "noodle",
 			},
 			wantErr: true,
@@ -104,7 +104,7 @@ func TestAssembleCommand(t *testing.T) {
 
 		{
 			name: "unknown format",
-			options: UploadOptions{
+			options: WriteOptions{
 				ImageFormat: "poodle",
 			},
 			wantErr: true,

--- a/hcloudimages/doc_test.go
+++ b/hcloudimages/doc_test.go
@@ -21,10 +21,12 @@ func ExampleClient_Upload() {
 	}
 
 	image, err := client.Upload(context.TODO(), hcloudimages.UploadOptions{
-		ImageURL:         imageURL,
-		ImageCompression: hcloudimages.CompressionBZ2,
-		Architecture:     hcloud.ArchitectureX86,
-		Location:         &hcloud.Location{Name: "nbg1"}, // Optional: defaults to fsn1
+		WriteOptions: hcloudimages.WriteOptions{
+			ImageURL:         imageURL,
+			ImageCompression: hcloudimages.CompressionBZ2,
+		},
+		Architecture: hcloud.ArchitectureX86,
+		Location:     &hcloud.Location{Name: "nbg1"}, // Optional: defaults to fsn1
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The new command `hcloud-upload-image write-to-disk` writes the image to the root disk of an existing server. It can be used to test images more quickly than the existing flow with `hcloud-upload-image upload`.

This is a breaking change of the `hcloudimages` Go Library, as the `hcloudimages.UploadOptions` struct is split up.

Closes #157 