### PR TITLE
fix: update hcloudimages module path for v2

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
 )
 
 // cleanupCmd represents the cleanup command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
 	"github.com/apricote/hcloud-upload-image/internal/ui"
 	"github.com/apricote/hcloud-upload-image/internal/version"
 )

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/spf13/cobra"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
 )
 
 const (

--- a/cmd/write-to-disk.go
+++ b/cmd/write-to-disk.go
@@ -12,8 +12,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0
+	github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.0
 	github.com/hetznercloud/hcloud-go/v2 v2.40.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
@@ -30,3 +30,5 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 )
+
+replace github.com/apricote/hcloud-upload-image/hcloudimages/v2 => ./hcloudimages

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0 h1:h9cxSQo8uYn7y5zLEOQF/GjLuXAqU9eVHt6vY/XIM1Y=
-github.com/apricote/hcloud-upload-image/hcloudimages v1.4.0/go.mod h1:9452aAvFQ28wGKZOMWS6djWvoQwqhbfUg6I2zEQIUXI=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/hcloudimages/client.go
+++ b/hcloudimages/client.go
@@ -13,12 +13,12 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/sshutil"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/internal/actionutil"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/internal/control"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/internal/labelutil"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/internal/randomid"
-	"github.com/apricote/hcloud-upload-image/hcloudimages/internal/sshsession"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/internal/actionutil"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/internal/control"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/internal/labelutil"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/internal/randomid"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/internal/sshsession"
 )
 
 const (

--- a/hcloudimages/doc.go
+++ b/hcloudimages/doc.go
@@ -36,7 +36,7 @@
 //
 // By default, nothing is logged. As the update process takes a bit of time you might want to gain some insight into
 // the process. For this we provide optional logs through [log/slog]. You can set a [log/slog.Logger] in the
-// [context.Context] through [github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger.New].
+// [context.Context] through [github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger.New].
 //
 // [Hetzner Cloud website]: https://www.hetzner.com/cloud/
 package hcloudimages

--- a/hcloudimages/doc_test.go
+++ b/hcloudimages/doc_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2"
 )
 
 func ExampleClient_Upload() {

--- a/hcloudimages/go.mod
+++ b/hcloudimages/go.mod
@@ -1,4 +1,4 @@
-module github.com/apricote/hcloud-upload-image/hcloudimages
+module github.com/apricote/hcloud-upload-image/hcloudimages/v2
 
 go 1.25.0
 

--- a/hcloudimages/internal/control/retry.go
+++ b/hcloudimages/internal/control/retry.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages/contextlogger"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2/contextlogger"
 )
 
 // Retry executes f at most maxTries times.


### PR DESCRIPTION
The current `hcloudimages/v2.0.0` tag is unusable.