### PR TITLE
chore(deps): update module github.com/apricote/hcloud-upload-image/hcloudimages to v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The functionality to upload images is also exposed in the library `hcloudimages`
 #### Install
 
 ```shell
-go get github.com/apricote/hcloud-upload-image/hcloudimages
+go get github.com/apricote/hcloud-upload-image/hcloudimages/v2
 ```
 
 #### Usages
@@ -149,7 +149,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 
-	"github.com/apricote/hcloud-upload-image/hcloudimages"
+	"github.com/apricote/hcloud-upload-image/hcloudimages/v2"
 )
 
 func main() {

--- a/default.nix
+++ b/default.nix
@@ -9,13 +9,13 @@ buildGoModule rec {
       (builtins.readFile ./internal/version/version.go));
 
   src = ./.;
-  vendorHash = "sha256-hwFyqwUYXV0Rge2kncf8Hr6d+cmxWoE45S3y51VhDy4=";
+  vendorHash = "sha256-K8d6Q6WYJw3SelckscSh1CJBecG+y11+q9UcMDyotLU=";
   env.GOWORK = "off";
   subPackages = ["."];
   goSum = ./go.sum; # make sure to rebuild
 
   postPatch = ''
-    echo 'replace github.com/apricote/hcloud-upload-image/hcloudimages => ./hcloudimages' >> go.mod
+    echo 'replace github.com/apricote/hcloud-upload-image/hcloudimages/v2 => ./hcloudimages' >> go.mod
   '';
 
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.26.4
 
 require (
-	github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.0
+	github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.1
 	github.com/hetznercloud/hcloud-go/v2 v2.40.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
@@ -30,5 +30,3 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 )
-
-replace github.com/apricote/hcloud-upload-image/hcloudimages/v2 => ./hcloudimages

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.1 h1:IX6IfhGIfA7gw51KlyBCU25dJuDEWIAtkWM9/F8aHC4=
+github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.1/go.mod h1:OBnyHwXlvUFZPqptHRGjDTPM0DWHOOhym2RVp8X+q5s=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/go.work.sum
+++ b/go.work.sum
@@ -10,9 +10,8 @@ github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HR
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/apricote/hcloud-upload-image/hcloudimages v1.1.0/go.mod h1:iJ95BaLfISZBY9X8K2Y2A5a49dI0RLjAuq+4BqlOSgA=
+github.com/apricote/hcloud-upload-image/hcloudimages/v2 v2.0.1/go.mod h1:OBnyHwXlvUFZPqptHRGjDTPM0DWHOOhym2RVp8X+q5s=
 github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
-github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
-github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dave/astrid v0.0.0-20170323122508-8c2895878b14 h1:YI1gOOdmMk3xodBao7fehcvoZsEeOyy/cfhlpCSPgM4=


### PR DESCRIPTION
Release-As: 1.5.0